### PR TITLE
Fix: Update profiles.ini path for Firefox installed via Snap

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -68,14 +68,14 @@ const GFirefoxProfilesIndicator = GObject.registerClass(FirefoxProfilesIndicator
  * @returns {Array} - Array of Firefox profiles
  */
 function getFirefoxProfiles(): string[] {
-    let filePath = GLib.get_home_dir() + '/.mozilla/firefox/profiles.ini';
-
-    // Handle edge case for Snap installation
-    if (!GLib.file_test(filePath, GLib.FileTest.EXISTS)) {
-        filePath = GLib.get_home_dir() + '/snap/firefox/common/.mozilla/firefox/profiles.ini';
-    }
-
-    if (!GLib.file_test(filePath, GLib.FileTest.EXISTS)) {
+    let filePaths = [
+        GLib.get_home_dir() + '/.mozilla/firefox/profiles.ini',
+        GLib.get_home_dir() + '/snap/firefox/common/.mozilla/firefox/profiles.ini' // Edge case for Snap installation
+    ];
+    
+    let filePath = filePaths.find(path => GLib.file_test(path, GLib.FileTest.EXISTS));
+    
+    if (!filePath) {
         Main.notify(EXTENSION_TITLE, 'Could not find the profiles.ini file.');
         return [];
     }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -68,7 +68,18 @@ const GFirefoxProfilesIndicator = GObject.registerClass(FirefoxProfilesIndicator
  * @returns {Array} - Array of Firefox profiles
  */
 function getFirefoxProfiles(): string[] {
-    let filePath = GLib.get_home_dir() + '/snap/firefox/common/.mozilla/firefox/profiles.ini';
+    let filePath = GLib.get_home_dir() + '/.mozilla/firefox/profiles.ini';
+
+    // Handle edge case for Snap installation
+    if (!GLib.file_test(filePath, GLib.FileTest.EXISTS)) {
+        filePath = GLib.get_home_dir() + '/snap/firefox/common/.mozilla/firefox/profiles.ini';
+    }
+
+    if (!GLib.file_test(filePath, GLib.FileTest.EXISTS)) {
+        Main.notify(EXTENSION_TITLE, 'Could not find the profiles.ini file.');
+        return [];
+    }
+
     let fileContent = GLib.file_get_contents(filePath)[1];
     let content = fileContent.toString();
     let namePattern = /Name=(.*)/g;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -68,7 +68,7 @@ const GFirefoxProfilesIndicator = GObject.registerClass(FirefoxProfilesIndicator
  * @returns {Array} - Array of Firefox profiles
  */
 function getFirefoxProfiles(): string[] {
-    let filePath = GLib.get_home_dir() + '/.mozilla/firefox/profiles.ini';
+    let filePath = GLib.get_home_dir() + '/snap/firefox/common/.mozilla/firefox/profiles.ini';
     let fileContent = GLib.file_get_contents(filePath)[1];
     let content = fileContent.toString();
     let namePattern = /Name=(.*)/g;


### PR DESCRIPTION
This PR resolves an issue where the extension fails to locate the profiles.ini file for Firefox installations via Snap.
Changes Made:
Updated the filePath to account for the Snap installation directory structure.
        Original Path:  ```~/.mozilla/firefox/profiles.ini```
        Updated Path: ```~/snap/firefox/common/.mozilla/firefox/profiles.ini```

Impact:
This change ensures compatibility with Firefox installed through Snap packages.

Please review and merge. Feedback is welcome!