### PR TITLE
chore(workspace): migrate URLs to gnome-extensions monorepo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # Firefox Profiles
 
+> **This extension is now maintained in the [gnome-extensions](https://github.com/baxyz/gnome-extensions) monorepo.**
+> New features and issues should go there. This repository is kept for historical reference.
+
 Easily launch Firefox with your favorite profile right from the indicator menu!
 
 Supports Firefox (regular, snap, and flatpak), Floorp (flatpak), and Zen (flatpak).
@@ -29,7 +32,7 @@ unzip firefox-profiles.zip -d ~/.local/share/gnome-shell/extensions/firefox-prof
 
 ### Compilation
 
-Please have a look to the official documentation on [Build and packaging automation ](https://gjs.guide/extensions/development/typescript.html#build-and-packaging-automation) for more information.
+Please have a look to the official documentation on [Build and packaging automation](https://gjs.guide/extensions/development/typescript.html#build-and-packaging-automation) for more information.
 
 You can run `make` to compile your code and generate the file `extension.js` inside the dist folder. If needed, it will install the dependencies using pnpm install.
 

--- a/metadata.json
+++ b/metadata.json
@@ -2,6 +2,6 @@
   "name": "Firefox Profiles",
   "description": "Easily launch Firefox with your favorite profile right from the indicator menu!\n\nSupports Firefox (regular, snap, and flatpak), Floorp (flatpak), and Zen (flatpak).\n\nNote: This extension is not sponsored, endorsed, or affiliated with Mozilla, Firefox, Floorp, or Zen; it's just pure profile-switching convenience!",
   "uuid": "firefox-profiles@arnaud.work",
-  "url": "https://github.com/baxyz/firefox-profiles",
+  "url": "https://github.com/baxyz/gnome-extensions",
   "shell-version": ["46", "47", "48", "49", "50"]
 }

--- a/package.json
+++ b/package.json
@@ -3,15 +3,16 @@
   "version": "4.0.0",
   "private": true,
   "description": "This GNOME extension streamlines launching Firefox profiles from the indicator menu.",
-  "homepage": "https://github.com/baxyz/firefox-profiles#readme",
+  "homepage": "https://github.com/baxyz/gnome-extensions/tree/main/extensions/firefox-profiles#readme",
   "bugs": {
-    "url": "https://github.com/baxyz/firefox-profiles/issues"
+    "url": "https://github.com/baxyz/gnome-extensions/issues"
   },
   "license": "AGPL-3.0-only",
   "author": "baxyz <berenger@arnaud.work>",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/baxyz/firefox-profiles.git"
+    "url": "git+https://github.com/baxyz/gnome-extensions.git",
+    "directory": "extensions/firefox-profiles"
   },
   "type": "module",
   "sideEffects": false,


### PR DESCRIPTION
## Summary

- Update `metadata.json` url → `baxyz/gnome-extensions`
- Update `package.json` homepage, bugs.url, repository (with `directory` field)
- Add deprecation notice in README pointing to the monorepo
- Fix pre-existing MD039 lint warning (trailing space in link text)

## Context

This extension is now maintained under [baxyz/gnome-extensions](https://github.com/baxyz/gnome-extensions/tree/main/extensions/firefox-profiles) as part of a GNOME Shell extensions monorepo. New features and issues should be tracked there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)